### PR TITLE
chore: make single call to getenv() for proxy url

### DIFF
--- a/colours.py
+++ b/colours.py
@@ -312,8 +312,8 @@ if __name__ == "__main__":
     if discord_bot_token is None:
         raise EnvironmentError("`DISCORD_BOT_TOKEN` was not provided.")
 
-    if getenv("PROXY_URL"):
+    if proxy_url := getenv("PROXY_URL"):
         from disnake.http import Route
-        Route.BASE = getenv("PROXY_URL")
+        Route.BASE = proxy_url
 	
     bot.run(discord_bot_token)


### PR DESCRIPTION
Makes using the `PROXY_URL` environment variable use a single `getenv()` call through the more Pythonic use of the walrus operator.